### PR TITLE
修复task3无法在gcc13环境下通过编译的问题，修复task3、task4无法在手动编译安装clang-14的环境下通过编译的问题，修正IRBuilder在代码块间切换的方法

### DIFF
--- a/task/3/CMakeLists.txt
+++ b/task/3/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB _src *.cpp *.hpp *.c *.h)
 add_executable(task3 ${_src})
 
-target_include_directories(task3 SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
+target_include_directories(task3 PRIVATE ${LLVM_INCLUDE_DIRS})
 
 target_link_libraries(task3 ${LLVM_LIBS})

--- a/task/3/EmitIR.cpp
+++ b/task/3/EmitIR.cpp
@@ -119,7 +119,7 @@ EmitIR::operator()(ReturnStmt* obj)
   mCurIrb->CreateRet(retVal);
 
   auto exitBb = llvm::BasicBlock::Create(mCtx, "return_exit", mCurFunc);
-  mCurIrb = std::make_unique<llvm::IRBuilder<>>(exitBb);
+  mCurIrb->SetInsertPoint(exitBb);
 }
 
 //==============================================================================
@@ -152,7 +152,7 @@ EmitIR::operator()(FunctionDecl* obj)
   if (obj->body == nullptr)
     return;
   auto entryBb = llvm::BasicBlock::Create(mCtx, "entry", func);
-  mCurIrb = std::make_unique<llvm::IRBuilder<>>(entryBb);
+  mCurIrb->SetInsertPoint(entryBb);
   auto& entryIrb = *mCurIrb;
 
   // TODO: 添加对函数参数的处理

--- a/task/3/asg.hpp
+++ b/task/3/asg.hpp
@@ -2,6 +2,7 @@
 
 #include "Obj.hpp"
 #include <string>
+#include <cstdint>
 
 namespace asg {
 

--- a/task/4/CMakeLists.txt
+++ b/task/4/CMakeLists.txt
@@ -2,6 +2,6 @@ file(GLOB _src *.cpp *.hpp *.c *.h)
 add_executable(task4 ${_src})
 
 target_include_directories(task4 PRIVATE . ${CMAKE_CURRENT_BINARY_DIR})
-target_include_directories(task4 SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
+target_include_directories(task4 PRIVATE ${LLVM_INCLUDE_DIRS})
 
 target_link_libraries(task4 ${LLVM_LIBS})


### PR DESCRIPTION
## 修复task3无法在gcc13环境下通过编译的问题
同#4

## 修复task3、task4无法在手动编译安装clang-14的环境下通过编译的问题
### 问题
```log
[build] /mnt/nvme0/home/luoyb/SYsU-lang2/task/3/Json2Asg.cpp:10:34: error: invalid operands to binary expression ('llvm::Optional<llvm::StringRef>' and 'const char[20]')
[build]   ASSERT(jobj->getString("kind") == "TranslationUnitDecl");
[build]          ~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~
[build] /mnt/nvme0/home/luoyb/SYsU-lang2/task/3/Obj.hpp:11:5: note: expanded from macro 'ASSERT'
[build]   ((expr) || (fprintf(stderr, "asserted at %s:%d\n", __FILE__, __LINE__),      \
[build]     ^~~~
[build] /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/llvm-14.0.6-4szl6q7ajio5q6cf6gjsp4rlxeeoytxb/include/llvm/ADT/StringRef.h:938:15: note: candidate function not viable: no known conversion from 'llvm::Optional<llvm::StringRef>' to 'llvm::StringRef' for 1st argument
[build]   inline bool operator==(StringRef LHS, StringRef RHS) {
[build]               ^
[build] /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/llvm-14.0.6-4szl6q7ajio5q6cf6gjsp4rlxeeoytxb/include/llvm/ADT/Optional.h:368:16: note: candidate function template not viable: no known conversion from 'const char[20]' to 'llvm::NoneType' for 2nd argument
[build] constexpr bool operator==(const Optional<T> &X, NoneType) {
[build]                ^
[build] /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/llvm-14.0.6-4szl6q7ajio5q6cf6gjsp4rlxeeoytxb/include/llvm/ADT/APInt.h:1986:13: note: candidate function not viable: no known conversion from 'llvm::Optional<llvm::StringRef>' to 'uint64_t' (aka 'unsigned long') for 1st argument
[build] inline bool operator==(uint64_t V1, const APInt &V2) { return V2 == V1; }
[build]             ^
[build] /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/llvm-14.0.6-4szl6q7ajio5q6cf6gjsp4rlxeeoytxb/include/llvm/ADT/APSInt.h:335:13: note: candidate function not viable: no known conversion from 'llvm::Optional<llvm::StringRef>' to 'int64_t' (aka 'long') for 1st argument
[build] inline bool operator==(int64_t V1, const APSInt &V2) { retu
```
### 原因
如果用户手动编译安装clang-14，会通过CPATH指定clang-14头文件目录，优先级高于-isystem指定的llvm17头文件目录
```log
#include "..." search starts here:
#include <...> search starts here:
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/llvm-14.0.6-4szl6q7ajio5q6cf6gjsp4rlxeeoytxb/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/lua-5.3.6-pmzyjvozdky425qdmoqvhb4i7bxzgywv/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/readline-8.2-q3iheyzb7ps24sbh2bjlwq54uoirwea4/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/libffi-3.4.4-asj5sv66z6j5vmhmmcyztohgvzxnmbj6/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/libedit-3.1-20210216-2czxzvgfshmhysh4czt6lyyv3y42imly/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/hwloc-2.9.1-aeqtrq62qavqodkxmrx4mqn55gzeltih/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/libpciaccess-0.17-5noubn57lzia75veaz35qrzqhgd2isjz/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/elfutils-0.190-y7awrtx3bqzg4z7227jpu3cnd6nrmlvv/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/pkgconf-1.9.5-jtpqkwono75ml64umlphmixaxwvjyotx/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/gettext-0.22.4-ah7uovdvn5kjeblif3wmip4ihcrjfzok/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/ncurses-6.4-dzfsc5bekfqzrsprwlumjinhxxp77evm/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/libxml2-2.10.3-puwsygwh7f3jwy7tychxcgmyeytxtxhv/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/libiconv-1.17-aalgrqrcur6ursgzgkblvumoonawhiyi/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/bzip2-1.0.8-ccrzobfr66lmnr3yalsjvxare3hefhn3/include
 .
 /mnt/nvme0/home/luoyb/SYsU-lang2/llvm/install/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/zlib-ng-2.1.5-ku7d3ijgv7svnn46j6bjo77tautkmbup/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/zstd-1.5.5-vtdscgao6ziutvj2q23gcis6ljjrv4x5/include
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-11.3.0/gcc-13.2.0-yyc7iaombcvantyucrdr37nanjnwy4dy/lib/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-11.3.0/gcc-13.2.0-yyc7iaombcvantyucrdr37nanjnwy4dy/lib/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/x86_64-pc-linux-gnu
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-11.3.0/gcc-13.2.0-yyc7iaombcvantyucrdr37nanjnwy4dy/lib/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/backward
 /mnt/nvme0/home/luoyb/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-13.2.0/llvm-14.0.6-4szl6q7ajio5q6cf6gjsp4rlxeeoytxb/lib/clang/14.0.6/include
 /usr/local/include
 /usr/include/x86_64-linux-gnu
 /usr/include
End of search list.
```
### 解决方法
修改cmake include选项以使用-I而不是-isystem

## 修正IRBuilder在代码块间切换的方法
反复创建IRBuilder在代码块足够多时可能会导致程序RE，使用正常切换方法`SetInsertPoint`可以避免这一问题。示例代码中应当使用更合理的代码块切换方法，以免造成误导。